### PR TITLE
Replace go get with go install

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ $ curl -sf https://gobinaries.com/tj/node-prune | sh
 From source:
 
 ```
-$ go get github.com/tj/node-prune
+$ go install github.com/tj/node-prune@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Since version 1.17 of Go `go get` is deprecated. It is suggested to work with `go install` instead.

https://go.dev/doc/go-get-install-deprecation